### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jrh3k5/xombi/security/code-scanning/2](https://github.com/jrh3k5/xombi/security/code-scanning/2)

The best way to fix this issue is to explicitly set the `permissions` key in the workflow YAML file. This can be done either at the workflow root (applies to all jobs) or at the job level (applies only to the specified job). Since the workflow does not appear to require any write permissions (it only checks out code, installs dependencies, runs tests, formats, and lints), the minimal permission required is `contents: read`. The most future-proof and broadly applicable fix is to add a `permissions: contents: read` block at the root of the workflow file, immediately after the `name` property and before the `on` property. No other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
