### PR TITLE
Use MySQL with Ombi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dist
 
 # Ignore configuration artifacts started up by Docker
 .docker/ombi/config
+.docker/mysql
 
 # Ignore local database artifacts
 xmtp-*.db3*

--- a/README.md
+++ b/README.md
@@ -108,7 +108,15 @@ This requires manual setup of the Ombi instance first, so run this command first
 docker compose up ombi -d
 ```
 
-Once it's running, navigate to http://localhost:9753 to set up Ombi. Once it's set up, obtain the Ombi API key from [here](http://localhost:9753/Settings/Ombi). Take note, also, of the user [here](http://localhost:9753/usermanagement) you want the bot to send your requests as to Ombi.
+Once it's running, navigate to http://localhost:9753 to set up Ombi. As part of the initial setup, choose MySQL as the database and provide the following values:
+
+- **Host**: `mysql`
+- **Port**: `3306`
+- **Database Name**: `ombi`
+- **User**: `ombi`
+- **Password**: `ombi_password`
+
+Once it's set up, obtain the Ombi API key from [here](http://localhost:9753/Settings/Ombi). Take note, also, of the user [here](http://localhost:9753/usermanagement) you want the bot to send your requests as to Ombi.
 
 Once you have the API key, create a `.env` file like so:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - xombi-network
   ombi:
     image: ghcr.io/linuxserver/ombi:v4.47.1-ls215
+    depends_on:
+      - mysql
     container_name: ombi
     restart: unless-stopped
     environment:
@@ -33,6 +35,21 @@ services:
       - ./.docker/ombi/config:/config
     ports:
       - "9753:3579"
+    networks:
+      - xombi-network
+  mysql:
+    image: mysql:8.0
+    container_name: ombi-mysql
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=ombi_root_password
+      - MYSQL_DATABASE=ombi
+      - MYSQL_USER=ombi
+      - MYSQL_PASSWORD=ombi_password
+    volumes:
+      - ./.docker/mysql/data:/var/lib/mysql
+    ports:
+      - "3306:3306"
     networks:
       - xombi-network
 


### PR DESCRIPTION
The SQLLite database chosen by default with Ombi often results in database lock errors. Use MySQL by default, instead.