### PR TITLE
Require app auth token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     env_file:
       - .env
     networks:
-      - xombi-network
+      xombi-network:
+        ipv4_address: 172.16.0.10
   ombi:
     image: ghcr.io/linuxserver/ombi:v4.47.1-ls215
     depends_on:
@@ -36,7 +37,8 @@ services:
     ports:
       - "9753:3579"
     networks:
-      - xombi-network
+      xombi-network:
+        ipv4_address: 172.16.0.20
   mysql:
     image: mysql:8.0
     container_name: ombi-mysql
@@ -51,8 +53,13 @@ services:
     ports:
       - "3306:3306"
     networks:
-      - xombi-network
+      xombi-network:
+        ipv4_address: 172.16.0.30
 
 networks:
   xombi-network:
     driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.0.0/24
+          gateway: 172.16.0.1

--- a/lib/webhook_initializer.test.ts
+++ b/lib/webhook_initializer.test.ts
@@ -318,25 +318,12 @@ describe("WebhookInitializer", () => {
         .requireMock("../ombi/webhook")
         .WebhookManager.mockReturnValue(mockWebhookManager);
 
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
-      const warnSpy = jest.spyOn(console, "warn").mockImplementation();
-
-      const result = await WebhookInitializer.initializeWebhookSystem(
-        config,
-        mockXmtpClient as unknown as Client,
-      );
-
-      expect(result).not.toBeNull();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Error setting up webhook:",
-        expect.any(Error),
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        "Continuing without webhook notifications",
-      );
-
-      consoleSpy.mockRestore();
-      warnSpy.mockRestore();
+      await expect(
+        WebhookInitializer.initializeWebhookSystem(
+          config,
+          mockXmtpClient as unknown as Client,
+        ),
+      ).rejects.toThrow("Registration failed");
     });
   });
 });

--- a/lib/webhook_initializer.test.ts
+++ b/lib/webhook_initializer.test.ts
@@ -219,6 +219,7 @@ describe("WebhookInitializer", () => {
       expect(mockWebhookServer.start).toHaveBeenCalledWith(3000);
       expect(mockWebhookManager.registerWebhook).toHaveBeenCalledWith(
         "http://192.168.1.100:3000/webhook",
+        "test-key",
       );
     });
 
@@ -254,6 +255,7 @@ describe("WebhookInitializer", () => {
 
       expect(mockWebhookManager.registerWebhook).toHaveBeenCalledWith(
         "http://custom:3000/webhook",
+        "test-key",
       );
     });
 

--- a/lib/webhook_initializer.ts
+++ b/lib/webhook_initializer.ts
@@ -152,31 +152,26 @@ export class WebhookInitializer {
     await webhookServer.start(webhookPort);
 
     // Register webhook with Ombi
-    try {
-      let webhookUrl: string;
+    let webhookUrl: string;
 
-      if (config.baseUrl) {
-        webhookUrl = `${config.baseUrl}/webhook`;
-        console.log(`Using custom webhook base URL: ${config.baseUrl}`);
-      } else {
-        webhookUrl = buildWebhookURL(webhookPort);
-      }
+    if (config.baseUrl) {
+      webhookUrl = `${config.baseUrl}/webhook`;
+      console.log(`Using custom webhook base URL: ${config.baseUrl}`);
+    } else {
+      webhookUrl = buildWebhookURL(webhookPort);
+    }
 
-      console.log(`Registering webhook URL: ${webhookUrl}`);
-      const registered = await webhookManager.registerWebhook(
-        webhookUrl,
-        config.applicationKey,
+    console.log(`Registering webhook URL: ${webhookUrl}`);
+    const registered = await webhookManager.registerWebhook(
+      webhookUrl,
+      config.applicationKey,
+    );
+    if (registered) {
+      console.log("Webhook successfully registered with Ombi");
+    } else {
+      console.warn(
+        "Failed to register webhook with Ombi - notifications may not work",
       );
-      if (registered) {
-        console.log("Webhook successfully registered with Ombi");
-      } else {
-        console.warn(
-          "Failed to register webhook with Ombi - notifications may not work",
-        );
-      }
-    } catch (error) {
-      console.error("Error setting up webhook:", error);
-      console.warn("Continuing without webhook notifications");
     }
 
     return {

--- a/lib/webhook_initializer.ts
+++ b/lib/webhook_initializer.ts
@@ -116,6 +116,12 @@ export class WebhookInitializer {
       return null;
     }
 
+    if (!config.applicationKey) {
+      throw new Error(
+        "An application key is required for webhook integrations.",
+      );
+    }
+
     this.validateConfig(config);
     console.log("Webhook notifications enabled - setting up webhook system");
 
@@ -157,7 +163,10 @@ export class WebhookInitializer {
       }
 
       console.log(`Registering webhook URL: ${webhookUrl}`);
-      const registered = await webhookManager.registerWebhook(webhookUrl);
+      const registered = await webhookManager.registerWebhook(
+        webhookUrl,
+        config.applicationKey,
+      );
       if (registered) {
         console.log("Webhook successfully registered with Ombi");
       } else {

--- a/lib/webhook_initializer.ts
+++ b/lib/webhook_initializer.ts
@@ -169,9 +169,7 @@ export class WebhookInitializer {
     if (registered) {
       console.log("Webhook successfully registered with Ombi");
     } else {
-      console.warn(
-        "Failed to register webhook with Ombi - notifications may not work",
-      );
+      throw new Error("Failed to register webhook with Ombi");
     }
 
     return {

--- a/ombi/webhook.test.ts
+++ b/ombi/webhook.test.ts
@@ -111,7 +111,10 @@ describe("WebhookManager", () => {
       mockedAxios.get.mockResolvedValue({ data: mockCurrentSettings });
       mockedAxios.post.mockResolvedValue({ data: true });
 
-      const result = await webhookManager.registerWebhook(mockWebhookUrl);
+      const result = await webhookManager.registerWebhook(
+        mockWebhookUrl,
+        mockApplicationToken,
+      );
 
       expect(result).toBe(true);
       expect(mockedAxios.post).toHaveBeenCalledWith(
@@ -119,7 +122,7 @@ describe("WebhookManager", () => {
         {
           enabled: true,
           webhookUrl: mockWebhookUrl,
-          applicationToken: null,
+          applicationToken: mockApplicationToken,
         },
         {
           headers: {
@@ -180,7 +183,10 @@ describe("WebhookManager", () => {
       mockedAxios.get.mockResolvedValue({ data: mockCurrentSettings });
       mockedAxios.post.mockResolvedValue({ data: false });
 
-      const result = await webhookManager.registerWebhook(mockWebhookUrl);
+      const result = await webhookManager.registerWebhook(
+        mockWebhookUrl,
+        mockApplicationToken,
+      );
 
       expect(result).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
@@ -200,7 +206,10 @@ describe("WebhookManager", () => {
       mockedAxios.get.mockResolvedValue({ data: mockCurrentSettings });
       mockedAxios.post.mockRejectedValue(mockError);
 
-      const result = await webhookManager.registerWebhook(mockWebhookUrl);
+      const result = await webhookManager.registerWebhook(
+        mockWebhookUrl,
+        mockApplicationToken,
+      );
 
       expect(result).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
@@ -213,7 +222,10 @@ describe("WebhookManager", () => {
       const mockError = new Error("Failed to fetch settings");
       mockedAxios.get.mockRejectedValue(mockError);
 
-      const result = await webhookManager.registerWebhook(mockWebhookUrl);
+      const result = await webhookManager.registerWebhook(
+        mockWebhookUrl,
+        mockApplicationToken,
+      );
 
       expect(result).toBe(false);
       expect(console.error).toHaveBeenCalledWith(

--- a/ombi/webhook.ts
+++ b/ombi/webhook.ts
@@ -55,7 +55,7 @@ export class WebhookManager {
    */
   async registerWebhook(
     webhookUrl: string,
-    applicationToken?: string,
+    applicationToken: string,
   ): Promise<boolean> {
     try {
       // First, check current settings to avoid unnecessary updates

--- a/ombi/webhook.ts
+++ b/ombi/webhook.ts
@@ -61,13 +61,14 @@ export class WebhookManager {
       // First, check current settings to avoid unnecessary updates
       const currentSettings = await this.getCurrentWebhookSettings();
 
-      // If webhook is already configured with the same URL, don't update
+      // If webhook is already configured with the same URL and application token, don't update
       if (
         currentSettings.enabled &&
-        currentSettings.webhookUrl === webhookUrl
+        currentSettings.webhookUrl === webhookUrl &&
+        currentSettings.applicationToken === applicationToken
       ) {
         console.log(
-          "Webhook already configured with the same URL, skipping registration",
+          "Webhook already configured with the same URL and application token, skipping registration",
         );
         return true;
       }
@@ -102,45 +103,6 @@ export class WebhookManager {
       }
     } catch (error) {
       console.error("Error registering webhook with Ombi:", error);
-      return false;
-    }
-  }
-
-  /**
-   * Un-registers this agent's webhook from Ombi.
-   * @returns true if the un-registration succeeded; false if not.
-   */
-  async unregisterWebhook(): Promise<boolean> {
-    try {
-      const webhookSettings: Partial<WebhookSettings> = {
-        enabled: false,
-        webhookUrl: null,
-        applicationToken: null,
-      };
-
-      const response = await axios.post(
-        `${this.ombiApiUrl}/api/v1/Settings/notifications/webhook`,
-        webhookSettings,
-        {
-          headers: {
-            ApiKey: this.ombiApiKey,
-            "Content-Type": "application/json",
-          },
-        },
-      );
-
-      if (response.data === true) {
-        console.log("Webhook successfully unregistered from Ombi");
-        return true;
-      } else {
-        console.error(
-          "Failed to unregister webhook, unexpected response:",
-          response.data,
-        );
-        return false;
-      }
-    } catch (error) {
-      console.error("Error unregistering webhook from Ombi:", error);
       return false;
     }
   }

--- a/webhook/server.test.ts
+++ b/webhook/server.test.ts
@@ -749,7 +749,7 @@ describe("WebhookServer", () => {
     it("should notify for RequestApproved notification type", async () => {
       const payload: WebhookPayload = {
         requestId: 123,
-        providerId: "550",
+        providerId: "551",
         type: "tv",
         requestStatus: "Processing Request",
         title: "Test Series",
@@ -764,7 +764,7 @@ describe("WebhookServer", () => {
         .expect(200);
 
       expect(mockNotificationHandler).toHaveBeenCalled();
-      expect(mockRequestTracker.hasRequest("550")).toBe(true); // Should NOT be removed for approved requests
+      expect(mockRequestTracker.hasRequest("551")).toBe(true); // Should NOT be removed for approved requests
     });
 
     it("should not notify for PendingApproval status", async () => {

--- a/webhook/server.test.ts
+++ b/webhook/server.test.ts
@@ -103,7 +103,7 @@ describe("WebhookServer", () => {
   });
 
   describe("middleware and security", () => {
-    it("should accept requests from allowlisted IP", async () => {
+    it("should accept requests from allowlisted IP with valid Access-Token", async () => {
       const payload: WebhookPayload = {
         requestId: 123,
         requestStatus: "Available",
@@ -113,6 +113,8 @@ describe("WebhookServer", () => {
       const response = await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -129,7 +131,49 @@ describe("WebhookServer", () => {
       const response = await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "192.168.1.100") // Not in allowlist
+        .expect(403);
+
+      expect(response.body).toEqual({ error: "Forbidden" });
+      expect(console.log).toHaveBeenCalledWith(
+        "Rejected unauthorized webhook request from:",
+        expect.any(String),
+      );
+    });
+
+    it("should reject requests without Access-Token header", async () => {
+      const payload: WebhookPayload = {
+        requestId: 123,
+        requestStatus: "Available",
+        notificationType: "MediaAvailable",
+      };
+
+      const response = await request(server["app"])
+        .post("/webhook")
+        .send(payload)
+        .set("X-Forwarded-For", "127.0.0.1")
+        .expect(403);
+
+      expect(response.body).toEqual({ error: "Forbidden" });
+      expect(console.log).toHaveBeenCalledWith(
+        "Rejected unauthorized webhook request from:",
+        expect.any(String),
+      );
+    });
+
+    it("should reject requests with invalid Access-Token", async () => {
+      const payload: WebhookPayload = {
+        requestId: 123,
+        requestStatus: "Available",
+        notificationType: "MediaAvailable",
+      };
+
+      const response = await request(server["app"])
+        .post("/webhook")
+        .send(payload)
+        .set("Access-Token", "invalid-token")
+        .set("X-Forwarded-For", "127.0.0.1")
         .expect(403);
 
       expect(response.body).toEqual({ error: "Forbidden" });
@@ -157,6 +201,7 @@ describe("WebhookServer", () => {
       const response = await request(testServer["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "::ffff:192.168.4.3") // IPv4-mapped IPv6
         .expect(200);
 
@@ -183,6 +228,7 @@ describe("WebhookServer", () => {
       const response = await request(testServer["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "192.168.4.3") // Regular IPv4
         .expect(200);
 
@@ -225,6 +271,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -251,6 +299,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -274,6 +324,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -303,6 +355,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -332,6 +386,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -356,6 +412,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -379,6 +437,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -401,6 +461,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -420,6 +482,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -439,6 +503,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -458,6 +524,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -482,6 +550,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -505,6 +575,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -524,6 +596,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -541,6 +615,8 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -558,6 +634,7 @@ describe("WebhookServer", () => {
       const response = await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -577,6 +654,7 @@ describe("WebhookServer", () => {
       const response = await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -592,6 +670,7 @@ describe("WebhookServer", () => {
       await request(server["app"])
         .post("/webhook")
         .send("invalid json")
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .set("Content-Type", "application/json")
         .expect(400);
@@ -617,6 +696,7 @@ describe("WebhookServer", () => {
       const response = await request(server["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(500);
 
@@ -691,6 +771,7 @@ describe("WebhookServer", () => {
       const response = await request(serverWithoutHandler["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -718,7 +799,7 @@ describe("WebhookServer", () => {
       await request(debugServer["app"])
         .post("/webhook")
         .send(payload)
-        .set("access-token", "another-token")
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -779,6 +860,7 @@ describe("WebhookServer", () => {
       await request(normalServer["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -809,6 +891,7 @@ describe("WebhookServer", () => {
       await request(normalServer["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("X-Forwarded-For", "127.0.0.1")
         .expect(200);
 
@@ -839,6 +922,7 @@ describe("WebhookServer", () => {
       await request(debugServer["app"])
         .post("/webhook")
         .send(payload)
+        .set("Access-Token", mockOmbiToken)
         .set("Authorization", "Some-Auth-Value") // Add auth header to test censoring
         .set("X-Forwarded-For", "127.0.0.1") // This will be rejected
         .expect(403);

--- a/webhook/server.ts
+++ b/webhook/server.ts
@@ -170,20 +170,24 @@ export class WebhookServer {
    * Convert an IP address to a 32-bit integer for CIDR comparison
    */
   private ipToInt(ip: string): number {
-    return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+    return (
+      ip
+        .split(".")
+        .reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0
+    );
   }
 
   /**
    * Check if an IP address is within a CIDR range
    */
   private isIPInCIDR(ip: string, cidr: string): boolean {
-    if (!cidr.includes('/')) {
+    if (!cidr.includes("/")) {
       return false; // Not a CIDR notation
     }
 
-    const [network, prefixLength] = cidr.split('/');
+    const [network, prefixLength] = cidr.split("/");
     const prefix = parseInt(prefixLength, 10);
-    
+
     if (prefix < 0 || prefix > 32) {
       return false; // Invalid prefix length
     }
@@ -199,7 +203,7 @@ export class WebhookServer {
    * Extract IPv4 address from IPv4-mapped IPv6 address
    */
   private extractIPv4FromMapped(ipv6: string): string | null {
-    if (ipv6.startsWith('::ffff:')) {
+    if (ipv6.startsWith("::ffff:")) {
       return ipv6.substring(7);
     }
     return null;
@@ -216,36 +220,50 @@ export class WebhookServer {
     const clientIP =
       req.ip || req.connection.remoteAddress || req.socket.remoteAddress;
 
+    if (!clientIP) {
+      return false;
+    }
+
+    // Extract IPv4 from IPv4-mapped IPv6 if applicable
+    const clientIPv4 = this.extractIPv4FromMapped(clientIP) || clientIP;
+
     let isAllowlistedIP = false;
     this.allowlistedIPs.forEach((allowlistedIP) => {
       if (isAllowlistedIP) {
         return;
       }
 
-      // Direct match
-      if (clientIP == allowlistedIP) {
+      // Check if allowlisted entry is a CIDR range
+      if (allowlistedIP.includes("/")) {
+        // CIDR range check - try both original client IP and extracted IPv4
+        if (this.isIPInCIDR(clientIPv4, allowlistedIP)) {
+          isAllowlistedIP = true;
+          return;
+        }
+        // Also check original IP in case it's IPv4 and we extracted from mapped
+        if (
+          clientIP !== clientIPv4 &&
+          this.isIPInCIDR(clientIP, allowlistedIP)
+        ) {
+          isAllowlistedIP = true;
+          return;
+        }
+        return;
+      }
+
+      // Direct match - check both original IP and extracted IPv4
+      if (clientIP === allowlistedIP || clientIPv4 === allowlistedIP) {
         isAllowlistedIP = true;
         return;
       }
 
-      // Handle IPv4-mapped IPv6 addresses
-      // If clientIP is IPv4-mapped (::ffff:x.x.x.x) and allowlisted is IPv4, compare the IPv4 parts
-      if (clientIP?.startsWith("::ffff:") && !allowlistedIP.includes(":")) {
-        const ipv4Part = clientIP.substring(7); // Remove "::ffff:" prefix
-        if (ipv4Part === allowlistedIP) {
-          isAllowlistedIP = true;
-          return;
-        }
-      }
-
-      // Handle reverse case: if allowlisted is IPv4-mapped and clientIP is IPv4
-      if (
-        allowlistedIP.startsWith("::ffff:") &&
-        clientIP &&
-        !clientIP.includes(":")
-      ) {
-        const ipv4Part = allowlistedIP.substring(7); // Remove "::ffff:" prefix
-        if (clientIP === ipv4Part) {
+      // Handle IPv4-mapped IPv6 addresses in allowlist
+      if (allowlistedIP.startsWith("::ffff:")) {
+        const allowlistedIPv4 = this.extractIPv4FromMapped(allowlistedIP);
+        if (
+          allowlistedIPv4 &&
+          (clientIP === allowlistedIPv4 || clientIPv4 === allowlistedIPv4)
+        ) {
           isAllowlistedIP = true;
           return;
         }


### PR DESCRIPTION
This change:

* Adds (and requires) the application token for webhook registration
* Makes sure that the webhook is registered with the application token
* Rejects requests that do not have the application token in the `Access-Token` header
* Adds support for the `RequestApproved` event, mostly to make it easier to test the webhook integration
* Adds support for CIDR blocks in the IP allowlist